### PR TITLE
fixup! feature: allow only regular file for hashing with `sum_file`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
-      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -17,6 +14,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUST_BACKTRACE: 1
 
 jobs:
   build:
@@ -28,7 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - Cargo.toml
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  build:
+    name: Rust on ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
+    needs:
+      - fmt
+      - clippy
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update toolchain & add llvm-tools
+        run: |
+          rustup update --no-self-update
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build
+
+      - name: Free space on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: cargo clean
+
+      - name: Run tests
+        run: cargo test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update toolchain & add rustfmt
+        run: |
+          rustup update
+          rustup component add rustfmt
+
+      - name: Run rustfmt
+        run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update toolchain & add clippy
+        run: |
+          rustup update --no-self-update
+          rustup component add clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 — 2025-04-23
+
+- [x] feature: generalize `path_file` argument type, from `&str` to `AsRef<Path>`
+
 ## 0.1.3 — 2025-04-19
 
 - [x] feature: make module constants public to allow their usage in user code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 — 2025-04-23
+
+- [x] feature: allow only regular file for hashing with `sum_file`
+
 ## 0.2.0 — 2025-04-23
 
 - [x] feature: generalize `path_file` argument type, from `&str` to `AsRef<Path>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 — 2025-04-23
+
+- [x] enhancement: add additional entropy to filename to fix race condition issue on parallel tests launch
+
 ## 0.3.0 — 2025-04-23
 
 - [x] feature: allow only regular file for hashing with `sum_file`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.3 — 2025-04-19
+
+- [x] feature: make module constants public to allow their usage in user code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imohash"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["hiql <qiu_lin@163.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imohash"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["hiql <qiu_lin@163.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imohash"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["hiql <qiu_lin@163.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imohash"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["hiql <qiu_lin@163.com>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ A rewritten version of [imohash](https://github.com/kalafut/imohash) in Rust.
 
 ## Usage
 
-Add this to your Cargo.toml:
+Add `imohash` as a dependency:
 
-```toml
-[dependencies]
-imohash = "0.1"
+```sh
+cargo add imohash
 ```
 
 then

--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ for:
 The original project created by
 [Jim Kalafut](https://github.com/kalafut), check out https://github.com/kalafut/imohash
 
-License: MIT
+## [Changelog](CHANGELOG.md)
+## [License (MIT)](LICENSE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ fn put_uvarint(mut buffer: impl AsMut<[u8]>, x: u64) -> usize {
 mod tests {
     use super::*;
     use md5::{Digest, Md5};
+    use std::time::{SystemTime, UNIX_EPOCH};
     use std::{fs, path::PathBuf};
 
     #[test]
@@ -132,13 +133,18 @@ mod tests {
         let test_data_dir = "test_data";
 
         if !Path::new(test_data_dir).exists() {
-            fs::create_dir(test_data_dir).unwrap();
+            fs::create_dir_all(test_data_dir).unwrap();
         }
 
         let mut path = PathBuf::new();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
         path.push(test_data_dir);
-        path.push(name);
-        return path.to_str().unwrap().to_string();
+        path.push(format!("{}.{}", name, nanos.to_string()));
+        path.to_str().unwrap().to_string()
     }
 
     #[test]
@@ -159,6 +165,7 @@ mod tests {
             fs::write(&sample_file, empty_byte_array).unwrap();
             let h1 = default_hasher.sum_file(&sample_file).unwrap();
             let h2 = custom_hasher.sum_file(&sample_file).unwrap();
+            fs::remove_file(&sample_file).unwrap();
             assert_eq!(h1, h2);
         }
     }
@@ -250,7 +257,8 @@ mod tests {
         assert_eq!(
             hex::encode(hash.to_le_bytes()),
             "2d9123b54d37e9b8f94ab37a7eca6f40"
-        )
+        );
+        fs::remove_file(&sample_file).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,8 +275,8 @@ mod tests {
     }
 
     #[cfg(windows)]
-    fn get_special_file() -> PathBuf {
-        PathBuf::from(r"\\.\CON")
+    fn get_special_file_path() -> &'static Path {
+        Path::new("\\\\.\\NUL")
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub struct Hasher {
 }
 
 impl Hasher {
-    /// Creates a new Hasher using the default sample size and sample threshhold values.
+    /// Creates a new Hasher using the default sample size and sample threshold values.
     pub fn new() -> Self {
         Self {
             sample_threshold: SAMPLE_THRESHOLD,
@@ -29,7 +29,7 @@ impl Hasher {
     }
 
     /// Creates a new Hasher using the provided sample size
-    /// and sample threshhold values. The entire file will be hashed
+    /// and sample threshold values. The entire file will be hashed
     /// (i.e. no sampling), if sampleSize < 1.
     pub fn with_sample_size_and_threshold(size: u32, threshold: u32) -> Self {
         Self {
@@ -38,13 +38,13 @@ impl Hasher {
         }
     }
 
-    /// Hashs a byte slice.
+    /// Hashes a byte slice.
     pub fn sum(&self, data: &[u8]) -> Result<u128> {
         let mut reader = BufReader::new(Cursor::new(data));
         self.hash(&mut reader)
     }
 
-    /// Hashs a file.
+    /// Hashes a file.
     pub fn sum_file(&self, path: &str) -> Result<u128> {
         let input_path = Path::new(path.trim());
         let path_canonicalized = input_path.canonicalize()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! It is based atop murmurhash3 and uses file size and sample data to construct the hash.
 
 use std::fs::File;
-use std::io::{BufReader, Cursor, Read, Result, Seek, SeekFrom};
+use std::io::{BufReader, Cursor, Error, Read, Result, Seek, SeekFrom};
 use std::path::Path;
 
 /// Default sample threshold value
@@ -46,7 +46,18 @@ impl Hasher {
 
     /// Hashes a file.
     pub fn sum_file<P: AsRef<Path>>(&self, path: P) -> Result<u128> {
-        let file_reader = File::open(path.as_ref().canonicalize()?)?;
+        let path = path.as_ref().canonicalize()?;
+
+        // allow only regular file, e.g. `/dev/random` will lead to memory leak
+        let metadata = std::fs::metadata(&path)?;
+        if !metadata.is_file() {
+            return Err(Error::other(format!(
+                "Path is not a file: {path:?}",
+                path = path
+            )));
+        }
+
+        let file_reader = File::open(path)?;
         let mut reader = BufReader::new(file_reader);
         self.hash(&mut reader)
     }
@@ -104,7 +115,6 @@ fn put_uvarint(mut buffer: impl AsMut<[u8]>, x: u64) -> usize {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use md5::{Digest, Md5};
     use std::{fs, path::PathBuf};
@@ -249,6 +259,35 @@ mod tests {
         let expected = "80a044c97d48f5702ed66776016de48d";
         let actual: u128 = hasher.sum_file("samples/system.evtx").unwrap();
         assert_eq!(expected, hex::encode(actual.to_le_bytes()));
+    }
+
+    #[cfg(unix)]
+    fn get_special_file_path() -> &'static Path {
+        Path::new("/dev/random")
+    }
+
+    #[cfg(windows)]
+    fn get_special_file() -> PathBuf {
+        PathBuf::from(r"\\.\CON")
+    }
+
+    #[test]
+    fn test_sum_file_for_special_file() {
+        // negative
+        let hasher = Hasher::new();
+        let special_file_path = get_special_file_path();
+        let result = hasher.sum_file(special_file_path);
+
+        match result {
+            Ok(_) => assert!(false),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                format!(
+                    "Path is not a file: \"{}\"",
+                    special_file_path.to_str().unwrap()
+                )
+            ),
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,9 @@ impl Hasher {
     }
 
     /// Hashes a file.
-    pub fn sum_file(&self, path: &str) -> Result<u128> {
-        let input_path = Path::new(path.trim());
-        let path_canonicalized = input_path.canonicalize()?;
-        let path_os_string = path_canonicalized.as_os_str();
-        let f = File::open(path_os_string)?;
-        let mut reader = BufReader::new(f);
+    pub fn sum_file<P: AsRef<Path>>(&self, path: P) -> Result<u128> {
+        let file_reader = File::open(path.as_ref().canonicalize()?)?;
+        let mut reader = BufReader::new(file_reader);
         self.hash(&mut reader)
     }
 
@@ -251,6 +248,15 @@ mod tests {
         let hasher = Hasher::new();
         let expected = "80a044c97d48f5702ed66776016de48d";
         let actual: u128 = hasher.sum_file("samples/system.evtx").unwrap();
+        assert_eq!(expected, hex::encode(actual.to_le_bytes()));
+    }
+
+    #[test]
+    fn test_sum_file_with_generalized_path_type() {
+        let hasher = Hasher::new();
+        let expected = "80a044c97d48f5702ed66776016de48d";
+        let path = PathBuf::from("samples/system.evtx");
+        let actual: u128 = hasher.sum_file(path).unwrap();
         assert_eq!(expected, hex::encode(actual.to_le_bytes()));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,11 @@ use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Result, Seek, SeekFrom};
 use std::path::Path;
 
-const SAMPLE_THRESHOLD: u32 = 128 * 1024;
-const SAMPLE_SIZE: u32 = 16 * 1024;
+/// Default sample threshold value
+pub const SAMPLE_THRESHOLD: u32 = 128 * 1024;
+
+/// Default sample size value
+pub const SAMPLE_SIZE: u32 = 16 * 1024;
 
 /// A hasher which holds the custom sample parameters, and provides the APIs
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
trying to get ci working on tests for windows job